### PR TITLE
Bump compat for HTTP

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 julia = "1.4"
 DataFrames = "1.2.2"
 EzXML = "1.1.0"
-HTTP = "0.9.16"
+HTTP = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
It looks like the CompatHelper github workflow didn't pick this up, maybe it needs updating as well?

https://github.com/JuliaRegistries/CompatHelper.jl/blob/master/.github/workflows/CompatHelper.yml

One possibility is to use https://github.com/julia-actions/MassInstallAction.jl